### PR TITLE
Let the database handle tag comparison

### DIFF
--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -72,27 +72,27 @@ module ActsAsTaggableOn
 
       return [] if list.empty?
 
-      duplicates = []
-      result = []
-      existing_tags = named_any_by_comparable_name(list)
-      list.each do |tag_name|
-        existing_tag = existing_tags[comparable_name(tag_name)]
-        if existing_tag
-          result << existing_tag
-        else
-          begin
-            result << Tag.create(:name => tag_name)
-          rescue ActiveRecord::RecordNotUnique
-            duplicates << tag_name
-          end
-        end
-      end
+      existing_tags = existing_tags_by_list_name(list)
 
-      if duplicates.empty?
-        result
-      else
-        result + Tag.named_any(duplicates)
+      list.map do |tag_name|
+        existing_tag = existing_tags[comparable_name(tag_name)]
+
+        existing_tag || Tag.create(:name => tag_name)
       end
+    end
+
+    def self.existing_tags_by_list_name(*list)
+      list = [list].flatten
+
+      return [] if list.empty?
+
+      if !ActsAsTaggableOn.strict_case_match && using_case_insensitive_collation?
+        names_to_find = sanitize_sql([(["SELECT '%s' AS name"]  * list.length).join( " UNION ALL " ), *list])
+        tags = ActsAsTaggableOn::Tag.select("#{all_columns}, names.name AS list_name").joins("INNER JOIN (#{names_to_find}) AS names ON tags.name = names.name")
+      else
+        tags = named_any(list).select("#{all_columns}, #{name_column} AS list_name")
+      end
+      Hash[tags.group_by { |tag| comparable_name(tag.list_name) }.map{|k,v| [k,v.first]}]
     end
 
     ### INSTANCE METHODS:
@@ -112,16 +112,16 @@ module ActsAsTaggableOn
     class << self
       private
 
-      def comparable_name(str)
-        as_8bit_ascii(str).downcase
+      def all_columns
+        "#{ActsAsTaggableOn::Tag.table_name}.*"
       end
 
-      # Get the list of tags and index them by the comparable_name for faster lookup
-      #
-      # @param *list [Array<Array>] Array of tag lists
-      # @return [Hash<comparable_name, tag_name>]
-      def named_any_by_comparable_name(list)
-        Hash[Tag.named_any(list).group_by{|tag| comparable_name(tag.name)}.map{|k,v| [k,v.first]}]
+      def name_column
+        "#{ActsAsTaggableOn::Tag.table_name}.name"
+      end
+
+      def comparable_name(str)
+        as_8bit_ascii(str).downcase
       end
 
       def binary

--- a/lib/acts_as_taggable_on/tag.rb
+++ b/lib/acts_as_taggable_on/tag.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 module ActsAsTaggableOn
   class Tag < ::ActiveRecord::Base
     include ActsAsTaggableOn::Utils

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -15,10 +15,18 @@ module ActsAsTaggableOn
         ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name == 'SQLite'
       end
 
+      def using_mysql?
+        ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name.downcase =~ /mysql/
+      end
+
+      def using_case_insensitive_collation?
+        using_mysql? && ::ActiveRecord::Base.connection.collation =~ /_ci\Z/
+      end
+
       def sha_prefix(string)
         Digest::SHA1.hexdigest("#{string}#{rand}")[0..6]
       end
-      
+
       private
       def like_operator
         using_postgresql? ? 'ILIKE' : 'LIKE'

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -16,7 +16,7 @@ module ActsAsTaggableOn
       end
 
       def using_mysql?
-        ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name.downcase =~ /mysql/
+        /mysql/ === ActiveRecord::Base.connection_config[:adapter]
       end
 
       def using_case_insensitive_collation?

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -19,6 +19,10 @@ module ActsAsTaggableOn
         ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name.downcase =~ /mysql/
       end
 
+      def using_case_insensitive_collation?
+        using_mysql? && ::ActiveRecord::Base.connection.collation =~ /_ci\Z/
+      end
+
       def sha_prefix(string)
         Digest::SHA1.hexdigest("#{string}#{rand}")[0..6]
       end

--- a/lib/acts_as_taggable_on/utils.rb
+++ b/lib/acts_as_taggable_on/utils.rb
@@ -19,10 +19,6 @@ module ActsAsTaggableOn
         ::ActiveRecord::Base.connection && ::ActiveRecord::Base.connection.adapter_name.downcase =~ /mysql/
       end
 
-      def using_case_insensitive_collation?
-        using_mysql? && ::ActiveRecord::Base.connection.collation =~ /_ci\Z/
-      end
-
       def sha_prefix(string)
         Digest::SHA1.hexdigest("#{string}#{rand}")[0..6]
       end

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -89,6 +89,27 @@ describe ActsAsTaggableOn::Tag do
     end
   end
 
+  if ActsAsTaggableOn::Tag.using_case_insensitive_collation?
+    describe "find or create with a case insensitive and accent insensitive database" do
+      before(:each) do
+        @tag.name = "inupiat"
+        @tag.save
+      end
+
+      it "should find existing tags case and accent insensitivly" do
+        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("IÑUPIAT").should == [@tag]
+      end
+
+      it "should find existing tags accent insensitivly" do
+        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("iñupiat").should == [@tag]
+      end
+
+      it "should not let tags with single quotes break the query" do
+        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("their's").map(&:name).should == ["their's"]
+      end
+    end
+  end
+
   it "should require a name" do
     @tag.valid?
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -89,27 +89,6 @@ describe ActsAsTaggableOn::Tag do
     end
   end
 
-  if ActsAsTaggableOn::Tag.using_case_insensitive_collation?
-    describe "find or create with a case insensitive and accent insensitive database" do
-      before(:each) do
-        @tag.name = "inupiat"
-        @tag.save
-      end
-
-      it "should find existing tags case and accent insensitivly" do
-        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("IÑUPIAT").should == [@tag]
-      end
-
-      it "should find existing tags accent insensitivly" do
-        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("iñupiat").should == [@tag]
-      end
-
-      it "should not let tags with single quotes break the query" do
-        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("their's").map(&:name).should == ["their's"]
-      end
-    end
-  end
-
   it "should require a name" do
     @tag.valid?
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -103,6 +103,10 @@ describe ActsAsTaggableOn::Tag do
       it "should find existing tags accent insensitivly" do
         ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("iñupiat").should == [@tag]
       end
+
+      it "should not let tags with single quotes break the query" do
+        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("their's").map(&:name).should == ["their's"]
+      end
     end
   end
 

--- a/spec/acts_as_taggable_on/tag_spec.rb
+++ b/spec/acts_as_taggable_on/tag_spec.rb
@@ -89,6 +89,23 @@ describe ActsAsTaggableOn::Tag do
     end
   end
 
+  if ActsAsTaggableOn::Tag.using_case_insensitive_collation?
+    describe "find or create with a case insensitive and accent insensitive database" do
+      before(:each) do
+        @tag.name = "inupiat"
+        @tag.save
+      end
+
+      it "should find existing tags case and accent insensitivly" do
+        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("IÑUPIAT").should == [@tag]
+      end
+
+      it "should find existing tags accent insensitivly" do
+        ActsAsTaggableOn::Tag.find_or_create_all_with_like_by_name("iñupiat").should == [@tag]
+      end
+    end
+  end
+
   it "should require a name" do
     @tag.valid?
 
@@ -192,12 +209,12 @@ describe ActsAsTaggableOn::Tag do
         duplicate_tag.stub(:validates_name_uniqueness?).and_return(false)
         duplicate_tag.save
         duplicate_tag.should be_persisted
-      end  
+      end
     end
 
     context "when do need unique names" do
       it "should run uniqueness validation" do
-        duplicate_tag.should_not be_valid        
+        duplicate_tag.should_not be_valid
       end
 
       it "add error to name" do

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -30,27 +30,4 @@ describe ActsAsTaggableOn::Utils do
       TaggableModel.using_mysql?.should be_false
     end
   end
-
-  describe "using_case_insensitive_collation?" do
-    context "when the adapter is mysql" do
-      before do
-        TaggableModel.connection.stub(:adapter_name).and_return("MySQL2")
-      end
-
-      it "should return true when the collation is case insensitive" do
-        TaggableModel.connection.stub(:collation).and_return("utf8_unicode_ci")
-        TaggableModel.using_case_insensitive_collation?.should be_true
-      end
-
-      it "should return false when the adapter is case sensitive" do
-        TaggableModel.connection.stub(:collation).and_return("utf8_bin")
-        TaggableModel.using_case_insensitive_collation?.should be_false
-      end
-    end
-
-    it "should return false when the adapter is not mysql" do
-      TaggableModel.connection.stub(:adapter_name).and_return("PostgreSQL")
-      TaggableModel.using_case_insensitive_collation?.should be_false
-    end
-  end
 end

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -21,12 +21,12 @@ describe ActsAsTaggableOn::Utils do
 
   describe "using_mysql?" do
     it "should return true when the adapter is mysql" do
-      TaggableModel.connection.stub(:adapter_name).and_return("MySQL2")
+      ActiveRecord::Base.stub(:connection_config).and_return(adapter: "mysql2")
       TaggableModel.using_mysql?.should be_true
     end
 
     it "should return false when the adapter is not mysql" do
-      TaggableModel.connection.stub(:adapter_name).and_return("PostgreSQL")
+      ActiveRecord::Base.stub(:connection_config).and_return(adapter: "postgresql")
       TaggableModel.using_mysql?.should be_false
     end
   end
@@ -34,7 +34,7 @@ describe ActsAsTaggableOn::Utils do
   describe "using_case_insensitive_collation?" do
     context "when the adapter is mysql" do
       before do
-        TaggableModel.connection.stub(:adapter_name).and_return("MySQL2")
+        ActiveRecord::Base.stub(:connection_config).and_return(adapter: "mysql2")
       end
 
       it "should return true when the collation is case insensitive" do
@@ -49,7 +49,7 @@ describe ActsAsTaggableOn::Utils do
     end
 
     it "should return false when the adapter is not mysql" do
-      TaggableModel.connection.stub(:adapter_name).and_return("PostgreSQL")
+      TaggableModel.stub(:using_mysql?).and_return(false)
       TaggableModel.using_case_insensitive_collation?.should be_false
     end
   end

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -30,4 +30,27 @@ describe ActsAsTaggableOn::Utils do
       TaggableModel.using_mysql?.should be_false
     end
   end
+
+  describe "using_case_insensitive_collation?" do
+    context "when the adapter is mysql" do
+      before do
+        TaggableModel.connection.stub(:adapter_name).and_return("MySQL2")
+      end
+
+      it "should return true when the collation is case insensitive" do
+        TaggableModel.connection.stub(:collation).and_return("utf8_unicode_ci")
+        TaggableModel.using_case_insensitive_collation?.should be_true
+      end
+
+      it "should return false when the adapter is case sensitive" do
+        TaggableModel.connection.stub(:collation).and_return("utf8_bin")
+        TaggableModel.using_case_insensitive_collation?.should be_false
+      end
+    end
+
+    it "should return false when the adapter is not mysql" do
+      TaggableModel.connection.stub(:adapter_name).and_return("PostgreSQL")
+      TaggableModel.using_case_insensitive_collation?.should be_false
+    end
+  end
 end

--- a/spec/acts_as_taggable_on/utils_spec.rb
+++ b/spec/acts_as_taggable_on/utils_spec.rb
@@ -18,4 +18,39 @@ describe ActsAsTaggableOn::Utils do
       TaggableModel.send(:like_operator).should == "LIKE"
     end
   end
+
+  describe "using_mysql?" do
+    it "should return true when the adapter is mysql" do
+      TaggableModel.connection.stub(:adapter_name).and_return("MySQL2")
+      TaggableModel.using_mysql?.should be_true
+    end
+
+    it "should return false when the adapter is not mysql" do
+      TaggableModel.connection.stub(:adapter_name).and_return("PostgreSQL")
+      TaggableModel.using_mysql?.should be_false
+    end
+  end
+
+  describe "using_case_insensitive_collation?" do
+    context "when the adapter is mysql" do
+      before do
+        TaggableModel.connection.stub(:adapter_name).and_return("MySQL2")
+      end
+
+      it "should return true when the collation is case insensitive" do
+        TaggableModel.connection.stub(:collation).and_return("utf8_unicode_ci")
+        TaggableModel.using_case_insensitive_collation?.should be_true
+      end
+
+      it "should return false when the adapter is case sensitive" do
+        TaggableModel.connection.stub(:collation).and_return("utf8_bin")
+        TaggableModel.using_case_insensitive_collation?.should be_false
+      end
+    end
+
+    it "should return false when the adapter is not mysql" do
+      TaggableModel.connection.stub(:adapter_name).and_return("PostgreSQL")
+      TaggableModel.using_case_insensitive_collation?.should be_false
+    end
+  end
 end


### PR DESCRIPTION
When the database is setup to be case insensitive, then use the database to determine which tags need to be created.
